### PR TITLE
Add `force_bulk_api_usage` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ pip install git+https://github.com/MeltanoLabs/tap-salesforce.git
   "start_date": "2017-11-02T00:00:00Z",
   "state_message_threshold": 1000,
   "max_workers": 8,
-  "streams_to_discover": ["Lead", "LeadHistory"]
+  "streams_to_discover": ["Lead", "LeadHistory"],
+  "force_bulk_api_usage": true
 }
 ```
 
@@ -76,6 +77,11 @@ The `max_workers` value is used to set the maximum number of threads used in ord
 The `streams_to_discover` value may contain a list of Salesforce streams (each ending up in a target table) for which the discovery is handled.
 By default, discovery is handled for all existing streams, which can take several minutes. With just several entities which users typically need it is running few seconds.
 The disadvantage is that you have to keep this list in sync with the `select` section, where you specify all properties(each ending up in a table column).
+
+The `force_bulk_api_usage` is used to define the behaviour when fields unsupported by "BULK" API are selected (defaults to `false`):
+
+- If `true` and `api_type` is "BULK", all unsupported fields are marked as unsupported and ignored.
+- If `false` and `api_type` is "BULK", the tap will use "REST" API for the streams with unsupported fields.
 
 ## Run Discovery
 


### PR DESCRIPTION
In the current implementation of the tap, fields that are unsupported by the Salesforce BULK API are excluded from the sync.

In this new PR, I'm introducing a new behaviour where:
- If `force_bulk_api_usage`  (default) is `false` and `api_type` is `BULK`, the tap switches to `REST` API, being able to fetch all fields.
- If `force_bulk_api_usage` is `true` and `api_type` is `BULK` , the `BULK` unsupported fields are excluded from the sync and `BULK` API is used in every call