### PR TITLE
Exclude compound fields when querying with BULK

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -189,7 +189,7 @@ def do_discover(sf: Salesforce, streams: list[str]):
                 f, mdata)
 
             # Compound Address fields cannot be queried by the Bulk API
-            if field_type == "address" and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
+            if (field_type == "address" or f["compoundFieldName"] is not None) and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
                 if sf.force_bulk_api_usage:
                     unsupported_fields.add(
                         (field_name, 'cannot query compound address fields with bulk API'))


### PR DESCRIPTION
With this change the tap starts excluding compound fields when querying with the `BULK` API, as these fields are incompatible.