### PR TITLE
Ensure blacklisted fields force usage of REST if not in `force_bulk_api_usage` mode

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -207,6 +207,7 @@ def do_discover(sf: Salesforce, streams: list[str]):
             if field_pair in sf.get_blacklisted_fields():
                 unsupported_fields.add(
                     (field_name, sf.get_blacklisted_fields()[field_pair]))
+                found_bulk_api_unsupported_field = True
 
             inclusion = metadata.get(
                 mdata, ('properties', field_name), 'inclusion')


### PR DESCRIPTION
Minor bugfix to ensure that the discover of blacklisted fields also sets the `found_bulk_api_unsupported_field` is set to `True`, ensuring that blacklisted fields also force the usage of `REST` API