### PR TITLE
Use `string` as default type for loose types

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -172,7 +172,7 @@ def field_to_property_schema(field, mdata):
     elif sf_type == "time":
         property_schema['type'] = "string"
     elif sf_type in LOOSE_TYPES:
-        return property_schema, mdata  # No type = all types
+        property_schema['type'] = "string"
     elif sf_type in BINARY_TYPES:
         mdata = metadata.write(mdata, ('properties', field_name), "inclusion", "unsupported")
         mdata = metadata.write(mdata, ('properties', field_name),


### PR DESCRIPTION
This PR introduces `string` as default value when fields can have multiple types (e.g. `AssetHistory.NewValue` and `AssetHistory.OldValue`).

The current implementation sets the type as `null`, which is not compatible with some targets (e.g. `pipelinewise-target-snowflake`). The sync does not fail, but simply ignores columns without types which, for a table like `AssetHistory` makes the table completely unusable (without `NewValue` nor `OldValue`.)