### PR TITLE
Revert change to use string as default for loose types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,6 @@ ENV/
 env.sh
 config.json
 .autoenv.zsh
+.idea/
 
 *~

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -172,7 +172,7 @@ def field_to_property_schema(field, mdata):
     elif sf_type == "time":
         property_schema['type'] = "string"
     elif sf_type in LOOSE_TYPES:
-        property_schema['type'] = "string"
+        return property_schema, mdata  # No type = all types
     elif sf_type in BINARY_TYPES:
         mdata = metadata.write(mdata, ('properties', field_name), "inclusion", "unsupported")
         mdata = metadata.write(mdata, ('properties', field_name),


### PR DESCRIPTION
Problem solved at the target level in [this fork](https://github.com/dlouseiro/pipelinewise-target-snowflake). [PR](https://github.com/transferwise/pipelinewise-target-snowflake/pull/420) opened upstream too. 