### PR TITLE
Fix response handling error

### DIFF
--- a/tap_salesforce/salesforce/bulk2.py
+++ b/tap_salesforce/salesforce/bulk2.py
@@ -62,7 +62,7 @@ class Bulk2:
                 break
 
             if status == "Failed":
-                raise Exception(f"Job failed: {resp.json()}")
+                raise Exception(f"Job failed: {resp}")
 
             time.sleep(BATCH_STATUS_POLLING_SLEEP)
 


### PR DESCRIPTION
Fix error where exception handling in `bulk2.py` is trying to apply a `response.json()` on an object which was already converted to a `dict` using `.json()` some lines of code before.