### PR TITLE
Fix: persist rotated refresh token in browser flow's cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## meltano.1.8.0
+
+  * Fix the browser (Authorization Code + PKCE) flow silently losing its
+    cached refresh token when Salesforce rotates it. On a cache-hit
+    refresh exchange, if the response included a new `refresh_token`
+    (some External Client App policies rotate it on every use), the
+    stale cached one was kept regardless -- once Salesforce invalidated
+    it, the next run had to fall back to a full browser round-trip.
+    Found via real end-to-end sandbox testing: browser mode reopened a
+    login window on a run that should have reused a cached token.
+    Now persists the rotated token when one is returned, and leaves the
+    cache untouched when the token comes back unchanged.
+
 ## meltano.1.7.0
 
   * Raise the minimum supported Python version to **3.10** (from an

--- a/tap_salesforce/salesforce/browser_auth.py
+++ b/tap_salesforce/salesforce/browser_auth.py
@@ -258,7 +258,9 @@ def acquire_token(
     Behaviour:
 
     1. If a refresh token is cached for ``(domain, client_id)``, silently
-       exchange it for a fresh access token and return.
+       exchange it for a fresh access token and return. If the refresh grant
+       response includes a new refresh token (some External Client App
+       policies rotate it on every use), the cache is updated with it.
     2. Otherwise — or if the cached refresh token is rejected by Salesforce —
        open the user's browser, complete the Authorization Code Flow with
        PKCE, cache the new refresh token, and return the access token.
@@ -279,10 +281,17 @@ def acquire_token(
     if cached_refresh_token is not None:
         try:
             body = _exchange_refresh_token(client_id, cached_refresh_token, domain)
+            # Some External Client App refresh token policies rotate the
+            # refresh token on every use. If Salesforce returned a new one,
+            # persist it -- otherwise the cache would silently go stale after
+            # a single reuse, forcing a full browser round-trip next time.
+            rotated_refresh_token = body.get("refresh_token")
+            if rotated_refresh_token and rotated_refresh_token != cached_refresh_token:
+                store_refresh_token(cache_dir, domain, client_id, rotated_refresh_token)
             return AcquiredToken(
                 access_token=body["access_token"],
                 instance_url=body["instance_url"],
-                refresh_token=cached_refresh_token,
+                refresh_token=rotated_refresh_token or cached_refresh_token,
             )
         except requests.HTTPError as e:
             LOGGER.warning("Cached refresh token rejected (%s); falling back to browser flow", e)

--- a/tests/test_browser_auth.py
+++ b/tests/test_browser_auth.py
@@ -172,6 +172,53 @@ class AcquireTokenTests(unittest.TestCase):
         self.assertEqual(token.access_token, "at-cached")
         self.assertEqual(token.refresh_token, "cached-rt")
 
+    def test_persists_rotated_refresh_token_on_cache_hit(self):
+        # Some External Client App refresh token policies rotate the refresh
+        # token on every use -- Salesforce returns a new one in the refresh
+        # grant response. The cache must be updated, or the next run's reuse
+        # of the now-stale cached token would be rejected, forcing an
+        # unnecessary browser round-trip.
+        with (
+            patch.object(browser_auth, "load_refresh_token", return_value="cached-rt"),
+            patch.object(
+                browser_auth,
+                "_exchange_refresh_token",
+                return_value={
+                    "access_token": "at-cached",
+                    "instance_url": "https://inst",
+                    "refresh_token": "rotated-rt",
+                },
+            ),
+            patch.object(browser_auth, "_run_browser_flow") as mock_browser,
+            patch.object(browser_auth, "store_refresh_token") as mock_store,
+        ):
+            token = browser_auth.acquire_token("ci", "picnic-nl.my", Path("/tmp/whatever"))
+
+        mock_browser.assert_not_called()
+        mock_store.assert_called_once_with(Path("/tmp/whatever"), "picnic-nl.my", "ci", "rotated-rt")
+        self.assertEqual(token.refresh_token, "rotated-rt")
+
+    def test_does_not_rewrite_cache_when_refresh_token_is_unchanged(self):
+        # Some policies echo the same refresh token back on every use rather
+        # than omitting it. That's not rotation -- don't treat it as one.
+        with (
+            patch.object(browser_auth, "load_refresh_token", return_value="cached-rt"),
+            patch.object(
+                browser_auth,
+                "_exchange_refresh_token",
+                return_value={
+                    "access_token": "at-cached",
+                    "instance_url": "https://inst",
+                    "refresh_token": "cached-rt",
+                },
+            ),
+            patch.object(browser_auth, "store_refresh_token") as mock_store,
+        ):
+            token = browser_auth.acquire_token("ci", "picnic-nl.my", Path("/tmp/whatever"))
+
+        mock_store.assert_not_called()
+        self.assertEqual(token.refresh_token, "cached-rt")
+
     def test_falls_back_to_browser_when_cached_refresh_token_is_rejected(self):
         # Mirrors what Salesforce returns for an expired/revoked refresh token:
         # 400 invalid_grant, surfaced by requests as an HTTPError.


### PR DESCRIPTION
## Summary

Found via real end-to-end sandbox testing: browser mode re-opened a login window on a run that should have silently reused a cached refresh token.

**Root cause:** on a cache-hit refresh exchange, `acquire_token` always returned/kept the *old* cached refresh token, ignoring any `refresh_token` Salesforce included in the grant response. Some External Client App refresh-token policies rotate the token on every use — once Salesforce invalidates the old one (having issued a new one we never stored), the next run's reuse attempt is rejected, forcing an unnecessary fallback to a full browser round-trip. Under a rotating policy this effectively defeated the point of caching: the browser would reopen on most runs instead of just the first.

**Fix:** if the refresh grant response includes a `refresh_token` different from the cached one, persist it and return it. If it comes back unchanged (or omitted, non-rotating policies), leave the cache untouched — no unnecessary keychain/file writes.

## Test plan

- [x] `pytest tests/` — 42/42 pass (2 new: cache-hit-with-rotation, cache-hit-with-unchanged-token).
- [x] `ruff check` / `ruff format --check` — clean.
- [x] Two consecutive real runs against a Salesforce sandbox — neither re-opened a browser (previously one of them did, which is how this was found).