### PR TITLE
Document fork lineage; fix install command pointing at wrong repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,42 @@
 # tap-salesforce
 
-[![CircleCI Build Status](https://circleci.com/gh/singer-io/tap-salesforce.png)](https://circleci.com/gh/singer-io/tap-salesforce.png)
-
-
 [Singer](https://www.singer.io/) tap that extracts data from a [Salesforce](https://www.salesforce.com/) Account and produces JSON-formatted data following the [Singer spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
 
-This is a forked version of [tap-salesforce (v1.4.24)](https://github.com/singer-io/tap-salesforce) that maintained by the Meltano team.
+## Fork lineage
 
-Main differences from the original version:
+This repo is a personal fork, two levels removed from the original:
 
-- Support for `username/password/security_token` authentication
-- Support for concurrent execution (8 threads by default) when accessing different API endpoints to speed up the extraction process
-- Support for much faster discovery
+```
+singer-io/tap-salesforce   (original Stitch project, last common version v1.4.24)
+        └─ MeltanoLabs/tap-salesforce   ("meltano." versions in CHANGELOG.md)
+                └─ dlouseiro/tap-salesforce   (this repo — "dlouseiro." versions)
+```
+
+- [`singer-io/tap-salesforce`](https://github.com/singer-io/tap-salesforce) — the original Stitch-maintained tap.
+- [`MeltanoLabs/tap-salesforce`](https://github.com/MeltanoLabs/tap-salesforce) — Meltano's fork, adding `username/password/security_token` auth, concurrent execution across streams, and faster discovery.
+- **This repo** — adds OAuth 2.0 (Client Credentials + browser/PKCE) authentication, a Python 3.10+ floor, and assorted fixes/config options (see `CHANGELOG.md`).
+
+### Versioning
+
+`CHANGELOG.md` entries and git tags are prefixed to show which fork introduced each change:
+
+| Prefix | Meaning |
+| --- | --- |
+| (none) / `meltano.` | Inherited from `MeltanoLabs/tap-salesforce` (or, further back, plain-numbered entries inherited from `singer-io/tap-salesforce`) |
+| `dlouseiro.` (changelog) / `dlouseiro-v*` (git tags) | Exclusive to this fork — never went upstream |
+
+Both lineages follow semver relative to their own prior version, not to each other — a `dlouseiro.` major bump doesn't imply anything about `MeltanoLabs`' own next release, and vice versa.
 
 # Quickstart
 
 ## Install the tap
 
-This version of `tap-salesforce` is not available on PyPi, so you have to fetch it directly from the Meltano maintained project:
+This version of `tap-salesforce` is not available on PyPI, so you fetch it directly from this fork:
 
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install git+https://github.com/MeltanoLabs/tap-salesforce.git
+pip install git+https://github.com/dlouseiro/tap-salesforce.git
 ```
 
 ## Create a Config file


### PR DESCRIPTION
## Summary

Found while documenting the `dlouseiro.`/`meltano.` versioning split (#25): the "Install the tap" section's `pip install` command pointed at `github.com/MeltanoLabs/tap-salesforce.git`, not this fork. Anyone following the README as written would install upstream Meltano's tap — missing every OAuth2 auth flow, the Python 3.10+ floor, dependency upgrades, and the rotated-refresh-token fix that only exist in this repo.

- **Fix**: install command now points at `dlouseiro/tap-salesforce.git`.
- Add an explicit "Fork lineage" section: `singer-io` → `MeltanoLabs` → this repo, with a short description of what each layer added.
- Add a "Versioning" subsection explaining the `dlouseiro.`/`meltano.` changelog and tag prefix scheme introduced in #25.
- Remove the CircleCI badge (pointed at `singer-io`'s own build status — irrelevant here, and this fork has no CI configured).
- Fold the old "Main differences from the original version" list into the new fork-lineage description (no information lost, just consolidated).

Best merged after #25, since this references the versioning scheme it introduces — but not a hard dependency (the README text doesn't rely on #25 actually being merged first, just describes the convention).